### PR TITLE
Update webpack-cli version to fix the issue when building.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,18 +41,20 @@
     "react-mark-ii": "^2.2.0"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.0.0-beta.46",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.1",
     "eslint": "^4.18.2",
     "eslint-loader": "^2.0.0",
     "eslint-plugin-react": "^7.7.0",
     "webpack": "^4.1.1",
-    "webpack-cli": "^2.0.13",
+    "webpack-cli": "^3.1.2",
     "webpack-concat-plugin": "^3.0.0-beta.0"
   },
   "engines": {


### PR DESCRIPTION
Fix the issue #134 

We can't build this with the master branch. To fix this issue, we need to update the `webpack-cli` version. Also, some other dependencies are necessary to install as new.