### PR TITLE
Reconnect the session when libssh2 returns -43 result code at the socket disconnected

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -150,7 +150,7 @@
   "verifyServerAuthenticityDescription": {
     "message": "The host key of the server differs from cache. This means that either the administrator has changed the host key, or a malicious computer pretends to be the server. Please verify whether the host key has actually been changed, before proceeding. Hit __Decline__ if your are not sure.",
     "description": "Dialog message in case the fingerprint of host mismatches with cache."
-  }, 
+  },
   "host": {
     "message": "Host",
     "description": "Title of the server host, used in details of the dialog."
@@ -158,7 +158,7 @@
   "algorithm": {
     "message": "Algorithm",
     "description": "Title of the fingerprint algorithm, used in details of the dialog."
-  }, 
+  },
   "fingerprint": {
     "message": "Fingerprint",
     "description": "Title of the fingerprint key itself, utsed in details of the dialog."
@@ -170,7 +170,7 @@
   "sftpThreadError_hostentIsNull" : {
     "message": "Server is not accessible",
     "description": "hostent is NULL"
-  }, 
+  },
   "sftpThreadError_connectFailed" : {
     "message": "Connecting failed",
     "description": "connect() failed"
@@ -296,5 +296,9 @@
   "sftpThreadError_gettingFileSizeFailed": {
     "message": "Unable to retrieve file size",
     "description": "Getting filesize failed"
+  },
+  "sftpThreadError_reconnected": {
+    "message": "Session reconnected",
+    "description": "Session was disconnected, but reconnected"
   }
 }

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -158,7 +158,7 @@
   "algorithm": {
     "message": "Versleutelingsmethode",
     "description": "Titel van sleuteltype, gebruikt in de details van het authenticatie venster."
-  }, 
+  },
   "fingerprint": {
     "message": "Sleutel",
     "description": "Titel van de sleutel, gebruikt in de details van het authenticatie venster."
@@ -168,7 +168,7 @@
   },
   "sftpThreadError_hostentIsNull" : {
     "message": "De server is niet bereikbaar"
-  }, 
+  },
   "sftpThreadError_connectFailed" : {
     "message": "Verbinden is mislukt"
   },
@@ -219,7 +219,7 @@
     "message": "Poging tot het verbreken van de SSH2-sessie is mislukt"
   },
   "sftpThreadError_sshCloseSessionFailedClearResources": {
-    "message": "Vrijmaken van de SSH2-sessie is mislukt" 
+    "message": "Vrijmaken van de SSH2-sessie is mislukt"
   },
   "sftpThreadError_sftpCloseFailed": {
     "message": "Poging tot het verbreken van de SFTP-sessie is mislukt"
@@ -265,5 +265,9 @@
   },
   "sftpThreadError_gettingFileSizeFailed": {
     "message": "Het ophalen van de bestandsgrootte is mislukt"
+  },
+  "sftpThreadError_reconnected": {
+    "message": "Sessie opnieuw verbonden",
+    "description": "Sessie is verbroken, maar opnieuw verbonden"
   }
 }

--- a/src/js/model/sftp_client.js
+++ b/src/js/model/sftp_client.js
@@ -342,12 +342,10 @@
         } else {
             if (onError) {
                 if (event.message === "error") {
-                    for (var i = 0; i < event.values.length; i++) {
-                        showNotification.call(this, event.values[i]);
-                    }
-                    onError(event.values[0]);
+                    showNotification.call(this, event.value.message);
+                    onError(event.value.message, event.value.result_code);
                 } else {
-                    onError("Unexpected message received(expect:" + message + " actual:" + event.message + ")");
+                    onError("Unexpected message received(expect:" + message + " actual:" + event.message + ")", 0);
                 }
             }
             return false;

--- a/src/nacl_src/create_file_command.cc
+++ b/src/nacl_src/create_file_command.cc
@@ -35,7 +35,7 @@ void CreateFileCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "CreateFileCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/delete_entry_command.cc
+++ b/src/nacl_src/delete_entry_command.cc
@@ -41,7 +41,7 @@ void DeleteEntryCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   if (sftp_handle) {
     CloseSftpHandle(sftp_handle);

--- a/src/nacl_src/get_metadata_command.cc
+++ b/src/nacl_src/get_metadata_command.cc
@@ -39,7 +39,7 @@ void GetMetadataCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "GetMetadataCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/make_directory_command.cc
+++ b/src/nacl_src/make_directory_command.cc
@@ -35,7 +35,7 @@ void MakeDirectoryCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "MakeDirectoryCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/read_directory_command.cc
+++ b/src/nacl_src/read_directory_command.cc
@@ -39,7 +39,7 @@ void ReadDirectoryCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "ReadDirectoryCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/read_file_command.cc
+++ b/src/nacl_src/read_file_command.cc
@@ -44,7 +44,7 @@ void ReadFileCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "ReadFileCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/rename_entry_command.cc
+++ b/src/nacl_src/rename_entry_command.cc
@@ -37,7 +37,7 @@ void RenameEntryCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   fprintf(stderr, "RenameEntryCommand::Execute End\n");
   delete this;

--- a/src/nacl_src/sftp.cc
+++ b/src/nacl_src/sftp.cc
@@ -155,10 +155,13 @@ void SftpInstance::OnShutdown(const int request_id)
   }
 }
 
-void SftpInstance::OnErrorOccurred(const int request_id, const std::string &message)
+void SftpInstance::OnErrorOccurred(const int request_id, const int result_code, const std::string &message)
 {
   fprintf(stderr, "SftpInstance::OnErrorOccurred\n");
-  SendResponse(request_id, std::string("error"), std::vector<std::string>{message});
+  pp::VarDictionary obj;
+  obj.Set(pp::Var("message"), pp::Var(message));
+  obj.Set(pp::Var("result_code"), pp::Var(result_code));
+  SendResponse(request_id, std::string("error"), obj);
 }
 
 void SftpInstance::OnMetadataListFetched(const int request_id,

--- a/src/nacl_src/sftp.h
+++ b/src/nacl_src/sftp.h
@@ -29,7 +29,7 @@ class SftpInstance : public pp::Instance, public SftpEventListener
                                    const std::string &hostkey_method);
   virtual void OnAuthenticationFinished(const int request_id);
   virtual void OnShutdown(const int request_id);
-  virtual void OnErrorOccurred(const int request_id,const std::string &message);
+  virtual void OnErrorOccurred(const int request_id, const int result_code, const std::string &message);
   virtual void OnMetadataListFetched(const int request_id,
                                      const std::vector<pp::Var> &metadataList);
   virtual void OnReadFile(const int request_id,

--- a/src/nacl_src/sftp_event_listener.h
+++ b/src/nacl_src/sftp_event_listener.h
@@ -18,6 +18,7 @@ class SftpEventListener
                                    const std::string &fingerprint,
                                    const std::string &hostkey_method) = 0;
   virtual void OnErrorOccurred(const int request_id,
+                               const int result_code,
                                const std::string &message) = 0;
   virtual void OnShutdown(const int request_id) = 0;
   virtual void OnAuthenticationFinished(const int request_id) = 0;

--- a/src/nacl_src/sftp_thread.cc
+++ b/src/nacl_src/sftp_thread.cc
@@ -56,7 +56,7 @@ void SftpThread::ConnectAndHandshake(const std::string server_hostname,
                    this);
     fprintf(stderr, "SftpThread::ConnectAndHandshake Thread started\n");
   } else {
-    listener_->OnErrorOccurred(request_id_, std::string("Thread already running"));
+    listener_->OnErrorOccurred(request_id_, 0, std::string("Thread already running"));
   }
 }
 
@@ -68,7 +68,7 @@ void SftpThread::Authenticate(const std::string auth_type,
   fprintf(stderr, "SftpThread::Authenticate\n");
   if (!thread_) {
     if (!session_) {
-      listener_->OnErrorOccurred(request_id_, std::string("Not connected and handshaked"));
+      listener_->OnErrorOccurred(request_id_, 0, std::string("Not connected and handshaked"));
       return;
     }
     auth_type_ = auth_type;
@@ -81,7 +81,7 @@ void SftpThread::Authenticate(const std::string auth_type,
                    this);
     fprintf(stderr, "SftpThread::Authenticate Thread started\n");
   } else {
-    listener_->OnErrorOccurred(request_id_, std::string("Thread already running"));
+    listener_->OnErrorOccurred(request_id_, 0, std::string("Thread already running"));
   }
 }
 
@@ -268,7 +268,7 @@ void SftpThread::Close()
                    this);
     fprintf(stderr, "SftpThread::Close Thread started\n");
   } else {
-    listener_->OnErrorOccurred(request_id_, std::string("Thread already running"));
+    listener_->OnErrorOccurred(request_id_, 0, std::string("Thread already running"));
   }
 }
 
@@ -317,7 +317,7 @@ void SftpThread::ConnectAndHandshakeImpl()
     server_sock_ = -1;
     session_ = NULL;
     thread_ = NULL;
-    listener_->OnErrorOccurred(request_id_, msg);
+    listener_->OnErrorOccurred(request_id_, e.getResultCode(), msg);
   }
   fprintf(stderr, "SftpThread::ConnectAndHandshakeImpl End\n");
 }
@@ -433,7 +433,7 @@ void SftpThread::AuthenticateImpl()
     std::string msg;
     msg = e.toString();
     thread_ = NULL;
-    listener_->OnErrorOccurred(request_id_, msg);
+    listener_->OnErrorOccurred(request_id_, e.getResultCode(), msg);
   }
   fprintf(stderr, "SftpThread::AuthenticateImpl End\n");
 }

--- a/src/nacl_src/truncate_file_command.cc
+++ b/src/nacl_src/truncate_file_command.cc
@@ -58,7 +58,7 @@ void TruncateFileCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   CloseSftpHandle(sftp_handle);
   fprintf(stderr, "TruncateFileCommand::Execute End\n");

--- a/src/nacl_src/write_file_command.cc
+++ b/src/nacl_src/write_file_command.cc
@@ -44,7 +44,7 @@ void WriteFileCommand::Execute()
   } catch(CommunicationException e) {
     std::string msg;
     msg = e.toString();
-    GetListener()->OnErrorOccurred(GetRequestID(), msg);
+    GetListener()->OnErrorOccurred(GetRequestID(), e.getResultCode(), msg);
   }
   if (sftp_handle) {
     CloseSftpHandle(sftp_handle);


### PR DESCRIPTION
## Abstract

This pull request adds an ability to try to reconnect a session after receiving the result code `-43` from libssh2.

## Issue fixed by this pull request

This app establishes a session to a SFTP server with libssh2 at mounting. However, the session is disconnected at some cases (ex. Chrome OS enters into sleep mode, the session comes timeout, and etc). In these cases, the libssh2 returns a result code `-43` (LIBSSH2_ERROR_SOCKET_RECV). The current version of this app can't handle any result codes, therefore, all operations are failed after disconnected.

## How to fix the issue

First, this pull request changes the C++ layer to inform the result code to the JavaScript layer. Next, if the result code is `-43`, try to reconnect to the SFTP server with calling the `resume` function.