### PR TITLE
Fix an issue at password mismatch.

### DIFF
--- a/src/js/model/sftp_fs.js
+++ b/src/js/model/sftp_fs.js
@@ -57,7 +57,7 @@
                         onSuccess();
                     }.bind(this));
             }.bind(this),
-            onError: handleResultCode.call(this, sftpClient, requestId, function(reason, resultCode) {
+            onError: handleResultCode.call(this, sftpClient, requestId, fileSystemId, function(reason, resultCode) {
                 onError(reason);
             }.bind(this))
         });


### PR DESCRIPTION
# Abstract

Fix an issue (an error message not displayed) at a password mismatch.

# Expected Behavior

An error message is displayed at filling in a wrong password and trying a mount.

# Actual Behavior

The error message is not displayed, and the UI is hanged.

# Reason

There are some lines to call the new function `handleResultCode` to check an error code from the NaCl layer. In one line of them, the passed arguments are wrong. For instance, I forgot to pass the `fileSystemId` argument...