### PR TITLE
Change the chunk size to 512KB for a stable a file writing operation.

### DIFF
--- a/src/js/model/sftp_client.js
+++ b/src/js/model/sftp_client.js
@@ -278,7 +278,7 @@
         var realPath = createRealPath.call(this, options.path);
         var start = 0;
         var doWriteFileData = function() {
-            var available = Math.min(32 * 1024, length - start);
+            var available = Math.min(512 * 1024, length - start);
             var view = new Uint8Array(data, start, available);
             var buffer = new ArrayBuffer(available);
             var bufferView = new Uint8Array(buffer);


### PR DESCRIPTION
# Abstract

To improve the stability of a file writing operation, change the chunk size.

# Expected Behavior

For example, when we try to copy one hundred files which their file size is about 6MB, all files are copied successfully.

# Actual Behavior

In the case above, the copying file operations are stopped after copying some files (the number of the files is about 10).

# Solution

Currently, a writing operation for a file is divided for each 32KB. The file system provider API usually requests a writing operation for each 512KB. That is, in the current implementation of this app, it is necessary to send 32KB 16 times for one writing request from the FSP API.

It seems that the chunk size is too small. When I tried to copy files like the above with the 512KB as the chunk size, the copy operations were stable. Also, the performance was increased.