### PR TITLE
Fix kex methods

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -189,6 +189,10 @@
     "message": "Initialization of SSH2 session failed",
     "description": "libssh2_session_init() failed"
   },
+  "sftpThreadError_sshKEXMethodPrefsFailed" : {
+    "message": "Couldn't set key exchange method preferences",
+    "description": "libssh_session_method_prefs() failed"
+  },
   "sftpThreadError_sshSessionHandshakeFailed" : {
     "message": "Finishing SSH2 session failed",
     "description": "Error when starting up SSH session"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -185,6 +185,9 @@
   "sftpThreadError_sshInitSessionFailed" : {
     "message": "Initialiseren van een SSH2-sessie is mislukt"
   },
+  "sftpThreadError_sshKEXMethodPrefsFailed" : {
+    "message": "Kan de voorkeuren voor de sleuteluitwisseling methode niet instellen"
+  },
   "sftpThreaderror_sshSessionHandshakeFailed" : {
     "message": "Voltooien van een SSH2-sessie is mislukt"
   },

--- a/src/nacl_src/sftp_thread.h
+++ b/src/nacl_src/sftp_thread.h
@@ -71,6 +71,7 @@ class SftpThread
   void InitializeLibssh2() throw(CommunicationException);
   int ConnectToSshServer(const std::string &hostname, const int port) throw(CommunicationException);
   LIBSSH2_SESSION* InitializeSession() throw(CommunicationException);
+  void SetKEXMethodPrefs(LIBSSH2_SESSION *session) throw(CommunicationException);
   void HandshakeSession(LIBSSH2_SESSION *session,
                         int sock) throw(CommunicationException);
   std::string GetHostKeyHash(LIBSSH2_SESSION *session);


### PR DESCRIPTION
Once a collection of four commits made on GitHub proper, and now a squashed commit of all four. The original commit comments are below.

> * Update sftp_thread.cc
> 
> Set our preferred keys to the default OpenSSH list. Because libssh2 is somewhat outdated in this category, it will only support `diffie-hellman-group-exchange-sha256` for the moment, but this _should_ help fix errors like #131. Still some more changes to make before this can be PR'd, but should be a lot closer. I hope.
> 
> * Update English messages
> 
> Dutch is next!
> 
> * Bijgewerkte Nederlandse berichten
> 
> Hoewel ik Google Translate heb gebruikt...
> 
> (For you English folk, that's an update to the Dutch messages, as promised in the previous commit.)
> 
> * Update sftp_thread.h
> 
> Gotta declare the method before we can define it.

By these commits combined, we should have universal compatibility with OpenSSH servers - as soon as `libssh2` adds the additional methods, that is. Anything more extensive may require switching to OpenSSH in the `webports` instead of `libssh2`.